### PR TITLE
Bump dry-configurable

### DIFF
--- a/credit_card_finder.gemspec
+++ b/credit_card_finder.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.13'
 
   spec.add_dependency 'credit_card_bins'
-  spec.add_runtime_dependency 'dry-configurable'
+  spec.add_runtime_dependency 'dry-configurable', '>= 0.13'
 end

--- a/lib/credit_card_finder/config.rb
+++ b/lib/credit_card_finder/config.rb
@@ -8,13 +8,13 @@ module CreditCardFinder
     extend Dry::Configurable
 
     setting :bincodes do
-      setting :api_key, '11111111111111'
-      setting :api_url, 'https://api.bincodes.com'
-      setting :timeout, 10
+      setting :api_key, default: '11111111111111'
+      setting :api_url, default: 'https://api.bincodes.com'
+      setting :timeout, default: 10
     end
 
-    setting :strategies, %w[CreditCardBinsStrategy BincodesStrategy]
+    setting :strategies, default: %w[CreditCardBinsStrategy BincodesStrategy]
 
-    setting :logger, Logger.new(STDOUT)
+    setting :logger, default: Logger.new(STDOUT)
   end
 end

--- a/lib/credit_card_finder/version.rb
+++ b/lib/credit_card_finder/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CreditCardFinder
-  VERSION = '0.1.6'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
Fixes deprecation warning for the new dry-configurable versions:

```
`<module:CreditCardFinder>' [dry-configurable] default value as positional argument to settings is deprecated and will be removed in the next major version
Provide a `default:` keyword argument instead
```